### PR TITLE
Fixes incorrect project/repo name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ please ask a question at
 
 # Issues
 If you encounter an issue with the project, you are welcome to submit a
-[bug report](github.ibm.com/Christopher-Wolf/logs-router-go-sdk/issues).
+[bug report](github.com/IBM/logs-router-go-sdk/issues).
 Before that, please search for similar issues. It's possible that someone has already reported the problem.
 
 # General Information

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/Christopher-Wolf/logs-router-go-sdk.svg?token=eW5FVD71iyte6tTby8gr&branch=main)](https://travis.ibm.com/Christopher-Wolf/logs-router-go-sdk.svg?token=eW5FVD71iyte6tTby8gr&branch=main)
+[![Build Status](https://travis-ci.com/IBM/logs-router-go-sdk.svg?token=eW5FVD71iyte6tTby8gr&branch=main)](https://travis.ibm.com/IBM/logs-router-go-sdk.svg?token=eW5FVD71iyte6tTby8gr&branch=main)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 # “IBM 0.0.1
@@ -20,17 +20,19 @@ Changes might occur which impact applications that use this SDK.
 
 <!-- toc -->
 
-- [Overview](#overview)
-- [Prerequisites](#prerequisites)
-- [Installation](#installation)
-  * [Go modules](#go-modules)
-  * [`go get` command](#go-get-command)
-- [Using the SDK](#using-the-sdk)
-- [Questions](#questions)
-- [Issues](#issues)
-- [Open source @ IBM](#open-source--ibm)
-- [Contributing](#contributing)
-- [License](#license)
+- [“IBM 0.0.1](#ibm-001)
+  - [Table of Contents](#table-of-contents)
+  - [Overview](#overview)
+  - [Prerequisites](#prerequisites)
+  - [Installation](#installation)
+    - [Go modules](#go-modules)
+    - [`go get` command](#go-get-command)
+  - [Using the SDK](#using-the-sdk)
+  - [Questions](#questions)
+  - [Issues](#issues)
+  - [Open source @ IBM](#open-source--ibm)
+  - [Contributing](#contributing)
+  - [License](#license)
 
 <!-- tocstop -->
 
@@ -60,7 +62,7 @@ Here is an example:
 
 ```go
 import (
-	"github.ibm.com/Christopher-Wolf/logs-router-go-sdk/exampleservicev1"
+	"github.com/IBM/logs-router-go-sdk/exampleservicev1"
 )
 ```
 Next, run `go build` or `go mod tidy` to download and install the new dependencies and update your application's
@@ -73,7 +75,7 @@ See the service table above to find the approprate package name for the services
 ### `go get` command  
 Alternatively, you can use the `go get` command to download and install the appropriate packages needed by your application:
 ```
-go get -u github.ibm.com/Christopher-Wolf/logs-router-go-sdk/exampleservicev1
+go get -u github.com/IBM/logs-router-go-sdk/exampleservicev1
 ```
 Be sure to use the appropriate package name from the service table above for the services used by your application.
 
@@ -88,7 +90,7 @@ please ask a question at
 
 ## Issues
 If you encounter an issue with the project, you are welcome to submit a
-[bug report](github.ibm.com/Christopher-Wolf/logs-router-go-sdk/issues).
+[bug report](github.com/IBM/logs-router-go-sdk/issues).
 Before that, please search for similar issues. It's possible that someone has already reported the problem.
 
 ## Open source @ IBM

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.ibm.com/Christopher-Wolf/logs-router-go-sdk
+module github.com/IBM/logs-router-go-sdk
 
 go 1.19
 

--- a/ibmlogsrouteropenapi30v0/ibm_logs_router_open_api_3_0_v0.go
+++ b/ibmlogsrouteropenapi30v0/ibm_logs_router_open_api_3_0_v0.go
@@ -29,7 +29,7 @@ import (
 	"reflect"
 	"time"
 
-	common "github.com/IBM/cloud-go-sdk/common"
+	common "github.com/IBM/logs-router-go-sdk/common"
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/go-openapi/strfmt"
 )

--- a/ibmlogsrouteropenapi30v0/ibm_logs_router_open_api_3_0_v0_examples_test.go
+++ b/ibmlogsrouteropenapi30v0/ibm_logs_router_open_api_3_0_v0_examples_test.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/IBM/cloud-go-sdk/ibmlogsrouteropenapi30v0"
+	"github.com/IBM/logs-router-go-sdk/ibmlogsrouteropenapi30v0"
 	"github.com/IBM/go-sdk-core/v5/core"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/ibmlogsrouteropenapi30v0/ibm_logs_router_open_api_3_0_v0_test.go
+++ b/ibmlogsrouteropenapi30v0/ibm_logs_router_open_api_3_0_v0_test.go
@@ -26,7 +26,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/IBM/cloud-go-sdk/ibmlogsrouteropenapi30v0"
+	"github.com/IBM/logs-router-go-sdk/ibmlogsrouteropenapi30v0"
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/go-openapi/strfmt"
 	. "github.com/onsi/ginkgo"


### PR DESCRIPTION
Points this repo to `github.com/IBM/logs-router-go-sdk` instead of `github.ibm.com/Christopher-Wolf/logs-router-go-sdk`