### PR TITLE
Changed Default Service URL to us-east prod; always add json content-…

### DIFF
--- a/ibmlogsrouteropenapi30v0/ibm_logs_router_open_api_3_0_v0.go
+++ b/ibmlogsrouteropenapi30v0/ibm_logs_router_open_api_3_0_v0.go
@@ -29,8 +29,8 @@ import (
 	"reflect"
 	"time"
 
-	common "github.com/IBM/logs-router-go-sdk/common"
 	"github.com/IBM/go-sdk-core/v5/core"
+	common "github.com/IBM/logs-router-go-sdk/common"
 	"github.com/go-openapi/strfmt"
 )
 
@@ -44,15 +44,15 @@ type IbmLogsRouterOpenApi30V0 struct {
 }
 
 // DefaultServiceURL is the default URL to make service requests to.
-const DefaultServiceURL = "https://management.private.eu-gb.logs-router.test.cloud.ibm.com/v1"
+const DefaultServiceURL = "https://management.us-east.logs-router.cloud.ibm.com/v1"
 
 // DefaultServiceName is the default key used to find external configuration information.
 const DefaultServiceName = "ibm_logs_router_open_api_3_0"
 
-const ParameterizedServiceURL = "https://management.private.{region}.logs-router.test.cloud.ibm.com/v1"
+const ParameterizedServiceURL = "https://management.{region}.logs-router.cloud.ibm.com/v1"
 
 var defaultUrlVariables = map[string]string{
-	"region": "eu-gb",
+	"region": "us-east",
 }
 
 // IbmLogsRouterOpenApi30V0Options : Service options
@@ -341,6 +341,7 @@ func (ibmLogsRouterOpenApi30 *IbmLogsRouterOpenApi30V0) GetTenantDetailWithConte
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
+	builder.AddHeader("Content-Type", "application/json")
 
 	request, err := builder.Build()
 	if err != nil {
@@ -401,6 +402,7 @@ func (ibmLogsRouterOpenApi30 *IbmLogsRouterOpenApi30V0) DeleteTenantWithContext(
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
+	builder.AddHeader("Content-Type", "application/json")
 
 	request, err := builder.Build()
 	if err != nil {
@@ -461,7 +463,7 @@ func (ibmLogsRouterOpenApi30 *IbmLogsRouterOpenApi30V0) UpdateTargetWithContext(
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
-	builder.AddHeader("Content-Type", "application/merge-patch+json")
+	builder.AddHeader("Content-Type", "application/json")
 
 	_, err = builder.SetBodyContentJSON(updateTargetOptions.TenantDetailsResponsePatch)
 	if err != nil {
@@ -513,10 +515,10 @@ type CreateTenantOptions struct {
 // NewCreateTenantOptions : Instantiate CreateTenantOptions
 func (*IbmLogsRouterOpenApi30V0) NewCreateTenantOptions(targetType string, targetHost string, targetPort int64, accessCredential string, targetInstanceCrn string) *CreateTenantOptions {
 	return &CreateTenantOptions{
-		TargetType: core.StringPtr(targetType),
-		TargetHost: core.StringPtr(targetHost),
-		TargetPort: core.Int64Ptr(targetPort),
-		AccessCredential: core.StringPtr(accessCredential),
+		TargetType:        core.StringPtr(targetType),
+		TargetHost:        core.StringPtr(targetHost),
+		TargetPort:        core.Int64Ptr(targetPort),
+		AccessCredential:  core.StringPtr(accessCredential),
 		TargetInstanceCrn: core.StringPtr(targetInstanceCrn),
 	}
 }
@@ -802,7 +804,7 @@ type UpdateTargetOptions struct {
 // NewUpdateTargetOptions : Instantiate UpdateTargetOptions
 func (*IbmLogsRouterOpenApi30V0) NewUpdateTargetOptions(tenantID *strfmt.UUID, tenantDetailsResponsePatch map[string]interface{}) *UpdateTargetOptions {
 	return &UpdateTargetOptions{
-		TenantID: tenantID,
+		TenantID:                   tenantID,
 		TenantDetailsResponsePatch: tenantDetailsResponsePatch,
 	}
 }

--- a/ibmlogsrouteropenapi30v0/ibm_logs_router_open_api_3_0_v0_test.go
+++ b/ibmlogsrouteropenapi30v0/ibm_logs_router_open_api_3_0_v0_test.go
@@ -26,8 +26,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/IBM/logs-router-go-sdk/ibmlogsrouteropenapi30v0"
 	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/logs-router-go-sdk/ibmlogsrouteropenapi30v0"
 	"github.com/go-openapi/strfmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -66,14 +66,13 @@ var _ = Describe(`IbmLogsRouterOpenApi30V0`, func() {
 		Context(`Using external config, construct service client instances`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"IBM_LOGS_ROUTER_OPEN_API_3_0_URL": "https://ibmlogsrouteropenapi30v0/api",
+				"IBM_LOGS_ROUTER_OPEN_API_3_0_URL":       "https://ibmlogsrouteropenapi30v0/api",
 				"IBM_LOGS_ROUTER_OPEN_API_3_0_AUTH_TYPE": "noauth",
 			}
 
 			It(`Create service client using external config successfully`, func() {
 				SetTestEnvironment(testEnvironment)
-				ibmLogsRouterOpenApi30Service, serviceErr := ibmlogsrouteropenapi30v0.NewIbmLogsRouterOpenApi30V0UsingExternalConfig(&ibmlogsrouteropenapi30v0.IbmLogsRouterOpenApi30V0Options{
-				})
+				ibmLogsRouterOpenApi30Service, serviceErr := ibmlogsrouteropenapi30v0.NewIbmLogsRouterOpenApi30V0UsingExternalConfig(&ibmlogsrouteropenapi30v0.IbmLogsRouterOpenApi30V0Options{})
 				Expect(ibmLogsRouterOpenApi30Service).ToNot(BeNil())
 				Expect(serviceErr).To(BeNil())
 				ClearTestEnvironment(testEnvironment)
@@ -102,8 +101,7 @@ var _ = Describe(`IbmLogsRouterOpenApi30V0`, func() {
 			})
 			It(`Create service client using external config and set url programatically successfully`, func() {
 				SetTestEnvironment(testEnvironment)
-				ibmLogsRouterOpenApi30Service, serviceErr := ibmlogsrouteropenapi30v0.NewIbmLogsRouterOpenApi30V0UsingExternalConfig(&ibmlogsrouteropenapi30v0.IbmLogsRouterOpenApi30V0Options{
-				})
+				ibmLogsRouterOpenApi30Service, serviceErr := ibmlogsrouteropenapi30v0.NewIbmLogsRouterOpenApi30V0UsingExternalConfig(&ibmlogsrouteropenapi30v0.IbmLogsRouterOpenApi30V0Options{})
 				err := ibmLogsRouterOpenApi30Service.SetServiceURL("https://testService/api")
 				Expect(err).To(BeNil())
 				Expect(ibmLogsRouterOpenApi30Service).ToNot(BeNil())
@@ -121,13 +119,12 @@ var _ = Describe(`IbmLogsRouterOpenApi30V0`, func() {
 		Context(`Using external config, construct service client instances with error: Invalid Auth`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"IBM_LOGS_ROUTER_OPEN_API_3_0_URL": "https://ibmlogsrouteropenapi30v0/api",
+				"IBM_LOGS_ROUTER_OPEN_API_3_0_URL":       "https://ibmlogsrouteropenapi30v0/api",
 				"IBM_LOGS_ROUTER_OPEN_API_3_0_AUTH_TYPE": "someOtherAuth",
 			}
 
 			SetTestEnvironment(testEnvironment)
-			ibmLogsRouterOpenApi30Service, serviceErr := ibmlogsrouteropenapi30v0.NewIbmLogsRouterOpenApi30V0UsingExternalConfig(&ibmlogsrouteropenapi30v0.IbmLogsRouterOpenApi30V0Options{
-			})
+			ibmLogsRouterOpenApi30Service, serviceErr := ibmlogsrouteropenapi30v0.NewIbmLogsRouterOpenApi30V0UsingExternalConfig(&ibmlogsrouteropenapi30v0.IbmLogsRouterOpenApi30V0Options{})
 
 			It(`Instantiate service client with error`, func() {
 				Expect(ibmLogsRouterOpenApi30Service).To(BeNil())
@@ -138,7 +135,7 @@ var _ = Describe(`IbmLogsRouterOpenApi30V0`, func() {
 		Context(`Using external config, construct service client instances with error: Invalid URL`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"IBM_LOGS_ROUTER_OPEN_API_3_0_AUTH_TYPE":   "NOAuth",
+				"IBM_LOGS_ROUTER_OPEN_API_3_0_AUTH_TYPE": "NOAuth",
 			}
 
 			SetTestEnvironment(testEnvironment)
@@ -166,7 +163,7 @@ var _ = Describe(`IbmLogsRouterOpenApi30V0`, func() {
 	Describe(`Parameterized URL tests`, func() {
 		It(`Format parameterized URL with all default values`, func() {
 			constructedURL, err := ibmlogsrouteropenapi30v0.ConstructServiceURL(nil)
-			Expect(constructedURL).To(Equal("https://management.private.eu-gb.logs-router.test.cloud.ibm.com/v1"))
+			Expect(constructedURL).To(Equal("https://management.eu-gb.logs-router.cloud.ibm.com/v1"))
 			Expect(constructedURL).ToNot(BeNil())
 			Expect(err).To(BeNil())
 		})


### PR DESCRIPTION
…type header

## PR summary
Changed default management API url to us-east non-private

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
Currently, the default management URL is private.eu-gb, which has not been made public

## What is the new behavior?  
Default management url is management.us-east.logs-router.cloud.ibm.com/v1

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->